### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Text/T9.pm
+++ b/lib/Text/T9.pm
@@ -1,5 +1,5 @@
 #= Guess words basing on a T9 key sequence
-module Text::T9;
+unit module Text::T9;
 
 =begin pod
 =head1 SYNOPSIS


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.