### PR TITLE
Replace 'done' with 'done-testing'

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -8,4 +8,4 @@ is t9_find_words(5477, @words).join('|'), 'kiss|lips', 'basic case';
 is t9_find_words(5296, ['jaźń'], { ź => 9, ń => 6 })[0], 'jaźń',
    'with optional keys';
 
-done;
+done-testing;


### PR DESCRIPTION
`done` is now only used in Supplies; `done-testing` is how we now specify
that testing is over.