### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Text::T9",
+    "license" : "MIT",
     "version" : "*",
     "description" : "Guess words basing on a T9 key sequence",
     "provides" : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license